### PR TITLE
fix(generator): escape special chars for path replacements with regex

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -96,8 +96,9 @@ const generateFile = options => new Promise((resolve, reject) => {
 const generateOperationFile = (config, operation, operation_name) => new Promise((resolve, reject) => {
   fs.readFile(path.join(config.root, config.file_name), 'utf8', (err, data) => {
     if (err) return reject(err);
+    const escaped_templates_dir = config.templates_dir.replace(/([.*+?^$|(){}\[\]])/mg, "\\$1");
     const subdir = config.root
-        .replace(new RegExp(`${config.templates_dir}[/]?`),'')
+        .replace(new RegExp(`${escaped_templates_dir}[/]?`),'')
         .replace("$$path$$", _.kebabCase(operation_name));
 
     const new_filename = config.file_name.replace('$$path$$', operation_name).replace(/.hbs$/, '');


### PR DESCRIPTION
If a projects path contains special characters, they will be intrepeted as
regular expresion instructions, which results in wrong output paths in the
end. To avoid this, special characters that can be used in regular
expressions should be escaped.

Fixes #32